### PR TITLE
Export image & fixed support for stylus with pressure.

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()

--- a/example/lib/drag_details.dart
+++ b/example/lib/drag_details.dart
@@ -1,0 +1,21 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class DragDetails {
+  /// The kind of pointer device.
+  final PointerDeviceKind? kind;
+
+  /// The local position at which the function was called.
+  final Offset localPosition;
+
+  /// The pressure of the pointer on the screen. 0 - 1
+  final double pressure;
+
+  const DragDetails(this.localPosition, [this.kind, this.pressure = 0.5]);
+
+  DragDetails.withPointer(PointerEvent pointerEvent)
+      : localPosition = pointerEvent.localPosition,
+        kind = pointerEvent.kind,
+        pressure = pointerEvent.pressure / pointerEvent.pressureMax;
+}

--- a/example/lib/drawing_page.dart
+++ b/example/lib/drawing_page.dart
@@ -1,24 +1,30 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:perfect_freehand/perfect_freehand.dart';
 
-import "sketcher.dart";
-import "stroke.dart";
+import 'sketcher.dart';
+import 'stroke.dart';
 import 'stroke_options.dart';
 
 class DrawingPage extends StatefulWidget {
-  const DrawingPage({Key? key}) : super(key: key);
+  const DrawingPage({Key? key, this.outCallback, required this.canvasSize})
+      : super(key: key);
+
+  final Function? outCallback;
+  final Size canvasSize;
 
   @override
-  _DrawingPageState createState() => _DrawingPageState();
+  State<DrawingPage> createState() => DrawingPageState();
 }
 
-class _DrawingPageState extends State<DrawingPage> {
+class DrawingPageState extends State<DrawingPage> {
   List<Stroke> lines = <Stroke>[];
 
   Stroke? line;
+  bool enabled = true;
 
   StrokeOptions options = StrokeOptions();
 
@@ -32,7 +38,35 @@ class _DrawingPageState extends State<DrawingPage> {
     setState(() {
       lines = [];
       line = null;
+      enabled = true;
     });
+  }
+
+  Future<void> image(BuildContext context) async {
+    final image = await toImage();
+    final futureBytes = await image.toByteData(format: ui.ImageByteFormat.png);
+    final pngBytes = futureBytes!.buffer.asUint8List();
+
+    showDialog(
+      context: context,
+      builder: (ctx) {
+        return Dialog(
+          elevation: 1,
+          insetPadding: const EdgeInsets.all(32.0),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(15.0),
+          ),
+          child: Padding(
+            padding: EdgeInsets.all(16.0),
+            child: SizedBox(
+              height: 500,
+              width: 500,
+              child: Image.memory(pngBytes),
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Future<void> updateSizeOption(double size) async {
@@ -42,26 +76,35 @@ class _DrawingPageState extends State<DrawingPage> {
   }
 
   void onPanStart(DragStartDetails details) {
+    if (details.kind == PointerDeviceKind.stylus) {}
     final box = context.findRenderObject() as RenderBox;
-    final offset = box.globalToLocal(details.globalPosition);
-    final point = Point(offset.dx, offset.dy);
-    final points = [point];
-    line = Stroke(points);
-    currentLineStreamController.add(line!);
+    if (checkPoint(
+        Point(details.localPosition.dx, details.localPosition.dy), box.size)) {
+      final offset = box.globalToLocal(details.globalPosition);
+      final point = Point(offset.dx, offset.dy);
+      final points = [point];
+      line = Stroke(points);
+      currentLineStreamController.add(line!);
+    }
   }
 
   void onPanUpdate(DragUpdateDetails details) {
     final box = context.findRenderObject() as RenderBox;
-    final offset = box.globalToLocal(details.globalPosition);
-    final point = Point(offset.dx, offset.dy);
-    final points = [...line!.points, point];
-    line = Stroke(points);
-    currentLineStreamController.add(line!);
+    if (checkPoint(
+        Point(details.localPosition.dx, details.localPosition.dy), box.size)) {
+      final offset = box.globalToLocal(details.globalPosition);
+      final point = Point(offset.dx, offset.dy);
+      final points = [...line!.points, point];
+      line = Stroke(points);
+      currentLineStreamController.add(line!);
+    }
   }
 
   void onPanEnd(DragEndDetails details) {
-    lines = List.from(lines)..add(line!);
-    linesStreamController.add(lines);
+    if (enabled) {
+      lines = List.from(lines)..add(line!);
+      linesStreamController.add(lines);
+    }
   }
 
   Widget buildCurrentPath(BuildContext context) {
@@ -71,28 +114,31 @@ class _DrawingPageState extends State<DrawingPage> {
       onPanEnd: onPanEnd,
       child: RepaintBoundary(
         child: Container(
-            color: Colors.transparent,
-            width: MediaQuery.of(context).size.width,
-            height: MediaQuery.of(context).size.height,
-            child: StreamBuilder<Stroke>(
-                stream: currentLineStreamController.stream,
-                builder: (context, snapshot) {
-                  return CustomPaint(
-                    painter: Sketcher(
-                      lines: line == null ? [] : [line!],
-                      options: options,
-                    ),
-                  );
-                })),
+          color: Colors.transparent,
+          width: double.infinity,
+          height: double.infinity,
+          child: StreamBuilder<Stroke>(
+            stream: currentLineStreamController.stream,
+            builder: (context, snapshot) {
+              return CustomPaint(
+                painter: Sketcher(
+                  lines: line == null ? [] : [line!],
+                  options: options,
+                ),
+              );
+            },
+          ),
+        ),
       ),
     );
   }
 
   Widget buildAllPaths(BuildContext context) {
     return RepaintBoundary(
-      child: SizedBox(
-        width: MediaQuery.of(context).size.width,
-        height: MediaQuery.of(context).size.height,
+      child: Container(
+        color: Colors.transparent,
+        width: double.infinity,
+        height: double.infinity,
         child: StreamBuilder<List<Stroke>>(
           stream: linesStreamController.stream,
           builder: (context, snapshot) {
@@ -224,22 +270,41 @@ class _DrawingPageState extends State<DrawingPage> {
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
               ),
-              buildClearButton(),
+              buildButtons(context),
             ]));
   }
 
-  Widget buildClearButton() {
-    return GestureDetector(
-      onTap: clear,
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 8.0),
-        child: const CircleAvatar(
-            child: Icon(
-          Icons.replay,
-          size: 20.0,
-          color: Colors.white,
-        )),
-      ),
+  Widget buildButtons(BuildContext context) {
+    return Row(
+      children: [
+        GestureDetector(
+          onTap: () {
+            image(context);
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: const CircleAvatar(
+                child: Icon(
+              Icons.image,
+              size: 20.0,
+              color: Colors.white,
+            )),
+          ),
+        ),
+        VerticalDivider(width: 30),
+        GestureDetector(
+          onTap: clear,
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: const CircleAvatar(
+                child: Icon(
+              Icons.replay,
+              size: 20.0,
+              color: Colors.white,
+            )),
+          ),
+        )
+      ],
     );
   }
 
@@ -262,5 +327,32 @@ class _DrawingPageState extends State<DrawingPage> {
     linesStreamController.close();
     currentLineStreamController.close();
     super.dispose();
+  }
+
+  bool isValidPoint(Point p, Size s) {
+    bool result = p.x > 0 && p.y > 0 && p.x < s.width && p.y < s.height;
+    return result;
+  }
+
+  bool checkPoint(Point p, Size s) {
+    bool isValid = isValidPoint(p, s);
+    if (!isValid && enabled && widget.outCallback != null) {
+      enabled = false;
+      widget.outCallback!();
+    }
+    return enabled && isValid;
+  }
+
+  Future<ui.Image> toImage() async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+
+    final ui.Canvas canvas = Canvas(recorder);
+
+    final sketcher = Sketcher(lines: lines, options: options);
+    final size = widget.canvasSize;
+    sketcher.paint(canvas, size);
+
+    final ui.Picture picture = recorder.endRecording();
+    return picture.toImage(size.width.toInt(), size.height.toInt());
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+
 import 'drawing_page.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  MyApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +17,14 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const DrawingPage(),
+      home: LayoutBuilder(builder: (context, constraints) {
+        return DrawingPage(
+          canvasSize: constraints.biggest,
+          // outCallback: () {
+          //   print('STOP: Drawing out of the canvas');
+          // },
+        );
+      }),
     );
   }
 }

--- a/lib/src/get_stroke_outline_points.dart
+++ b/lib/src/get_stroke_outline_points.dart
@@ -118,14 +118,12 @@ List<Point> getStrokeOutlinePoints(
           1,
           prevPressure + (rp - prevPressure) * (sp * rateOfPressureChange),
         );
-        radius = getStrokeRadius(
-          size,
-          thinning,
-          pressure,
-        );
-      } else {
-        radius = size / 2;
       }
+      radius = getStrokeRadius(
+        size,
+        thinning,
+        pressure,
+      );
     }
 
     firstRadius ??= radius;

--- a/lib/src/get_stroke_points.dart
+++ b/lib/src/get_stroke_points.dart
@@ -70,7 +70,8 @@ List<StrokePoint> getStrokePoints(
     if (isComplete && i == pts.length - 1) {
       point = pts[i];
     } else {
-      point = lrp(prev.point, pts[i], t);
+      final tempPoint = lrp(prev.point, pts[i], t);
+      point = Point(tempPoint.x, tempPoint.y, pts[i].p);
     }
 
     if (isEqual(point, prev.point)) {


### PR DESCRIPTION
1. Added a button for exporting images (and png) in example app.

2. Applied changes from issue https://github.com/steveruizok/perfect-freehand-dart/issues/4 . Thanks to @ercgeek. Tested with Apple Pencil and Samsung Galaxy Tab A. I couldn't make [ForcePressGestureRecognizer](https://api.flutter.dev/flutter/gestures/ForcePressGestureRecognizer-class.html) to work so I used [Listener](https://api.flutter.dev/flutter/widgets/Listener-class.html) instead in example app.

3. Added some features I needed: 
* A listener that triggers when drawing outside the canvas
* A flag to block normal touches after starting a drawing with a stylus.