### PR TITLE
Implemented stylus pressure in radius calculation, StrokePoint generation, and example app (Resolves #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,47 @@
-# Files and directories created by pub.
-.dart_tool/
-.packages
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
 
-# Conventional directory for build output.
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/lib/src/get_stroke_outline_points.dart
+++ b/lib/src/get_stroke_outline_points.dart
@@ -124,7 +124,11 @@ List<Point> getStrokeOutlinePoints(
           pressure,
         );
       } else {
-        radius = size / 2;
+        radius = getStrokeRadius(
+          size,
+          thinning,
+          pressure,
+        );
       }
     }
 

--- a/lib/src/get_stroke_points.dart
+++ b/lib/src/get_stroke_points.dart
@@ -71,6 +71,11 @@ List<StrokePoint> getStrokePoints(
       point = pts[i];
     } else {
       point = lrp(prev.point, pts[i], t);
+
+      if (!simulatePressure) {
+        // Use real pressure.
+        point = Point(point.x, point.y, pts[i].p);
+      }
     }
 
     if (isEqual(point, prev.point)) {


### PR DESCRIPTION
Implemented stylus pressure in radius calculation, StrokePoint generation, and example app (Resolves #5)

The calculation behavior wasn't considering pressure when calculating the radius, nor interpolating the points. This PR adds that.

Also, the example app was using a `GestureDetector`, which doesn't report pressure. I switch it to a `Listener`, which reports the kind of device, and in the case of a stylus, includes pressure.

I also updated the .gitignore to match a standard Flutter project.