### PR TITLE
fix: prevent RangeError in updatePressure

### DIFF
--- a/lib/src/get_stroke_points.dart
+++ b/lib/src/get_stroke_points.dart
@@ -111,7 +111,10 @@ List<StrokePoint> getStrokePoints(
       // The adjusted point
       point: point,
       // A function to update the pressure of the point
-      updatePressure: (pressure) => updatePressure(i, pressure),
+      updatePressure: (pressure) => updatePressure(
+        (points.length == 2 && i >= 2) ? 1 : i, 
+        pressure
+      ),
       // The vector from the current point to the previous point
       vector: point.unitVectorTo(prev.point),
       // The distance between the current point and the previous point


### PR DESCRIPTION
The for loop in which `updatePressure(i, pressure)` is called is iterating over `pts`. When a stroke consists of only two points, additional points are added to `pts`, so `pts` has more points than `points` and `updatePressure()`, which updates `points`, is called points that don't exist. This results in errors like `Another exception was thrown: RangeError (length): Invalid value: Not in inclusive range 0..1: 4`.
This commit fixes this behavior by changing the point that is updated in the for loop to the second point, if the stroke is consisting of exactly two points and `i` is larger than 1.
This fix is needed to fix [https://github.com/saber-notes/saber/issues/1391](https://github.com/saber-notes/saber/issues/1391).